### PR TITLE
added Dockerfile and GitHub Action to build and push docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,5 +27,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/nettie168/Haunted-City:latest
-            ghcr.io/nettie168/Haunted-City:${{ github.sha }}
+            ghcr.io/nettie168/haunted-city:latest
+            ghcr.io/nettie168/haunted-city:${{ github.sha }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,31 @@
+name: publish
+on:
+  push:
+    branches:
+      - "main"
+
+permissions:
+  packages: write
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/nettie168/Haunted-City:latest
+            ghcr.io/nettie168/Haunted-City:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:23-alpine
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+COPY package*.json ./
+USER node
+RUN npm install
+COPY --chown=node:node . .
+EXPOSE 3000
+CMD [ "node", "index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:23-alpine
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 WORKDIR /home/node/app
-COPY package*.json ./
+COPY package.json ./
 USER node
 RUN npm install
 COPY --chown=node:node . .


### PR DESCRIPTION
This allows the site to be deployed as a docker container, rather than via git clone. 

The GitHub action in .github/workflows/publish.yaml publishes builds the docker image when there is a push to main, and pushes it to the GitHub container registry.